### PR TITLE
Open multiseries tiff and nd2 files

### DIFF
--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -1592,7 +1592,7 @@ def load(file_name: Union[str, List[str]],
                 else:
                     input_arr = np.array(nd2)
 
-        if extension in ['.tif', '.tiff', '.btf']:  # load tif file
+        elif extension in ['.tif', '.tiff', '.btf']:  # load tif file
             with tifffile.TiffFile(file_name) as tffl:
                 
                 if len(tffl.series)>1:

--- a/caiman/base/movies.py
+++ b/caiman/base/movies.py
@@ -36,6 +36,7 @@ from sklearn.decomposition import NMF, IncrementalPCA, FastICA
 from sklearn.metrics.pairwise import euclidean_distances
 import sys
 import tifffile
+from nd2reader import ND2Reader
 from tqdm import tqdm
 from typing import Any, Dict, List, Tuple, Union
 import warnings
@@ -1371,6 +1372,92 @@ class movie(ts.timeseries):
             for i in range(10):
                 cv2.waitKey(100)
 
+def load_multiseries_tiff(file_name: Union[str, List[str]],
+                          initialFrame: int=0, 
+                          step: int=1, 
+                          finalFrame: int=None, 
+                          outtype = np.float32):
+    """
+    load any tiff file, multiseries or multipage. Supports the .tif and .tiff formats
+    
+    Variables:
+        file_name: name of file. Possible extensions are .tif and .tiff
+        initialFrame: Initial frame to load.
+        step: space between two consecutive extracted frames
+        finalFrame: Final frame to load. If None, the final Frame is the final frame of the video.
+        dtype: dtype for the output array
+        
+    Returns:
+        outputImage: Numpy array of dtype. If caiman is True, if returns a caiman movie type.
+
+    """
+
+    #Check if the filename exists
+    if os.path.exists(file_name):
+        fileExtension = os.path.splitext(file_name)[-1]
+        
+        #Get tiff file otherwise give a warning and return None
+        if(fileExtension == '.tif' or fileExtension == '.tiff'):
+            tffl = tifffile.TiffFile(file_name)
+            
+            if step is None:
+                step=1
+            
+            #Count variable for the frames
+            T = 0
+            
+            #outputImage varible initialization
+            outputImage = None
+            
+            #For cycle that iterates over the series
+            for seriesNr in range(0,len(tffl.series)):
+                seriesFrames = tffl.series[seriesNr].shape[0] # Number of frames in the series
+                
+                if (outputImage is None):   #If the first frame was still not found
+                    if seriesFrames <= initialFrame:    #If the initialFrame is not in the open series continue
+                        initialFrame -= seriesFrames
+                    else:                               #Else, get either all the series or just the frames until the finalFrame requested
+                        if(finalFrame is not None and finalFrame<=seriesFrames):
+                            outputImage = tffl.series[seriesNr].asarray(key=range(initialFrame,finalFrame,step))
+                            break
+                        else:
+                            outputImage = tffl.series[seriesNr].asarray(key=range(initialFrame,seriesFrames,step))
+
+                    # If series are single paged, create an extra axis to stack the frames on
+                    if outputImage is not None and len(outputImage.shape)==2:
+                        outputImage = outputImage[np.newaxis,:, :]
+                
+                else:   #If some frames are already obtained from previous series, stack next frames
+                    if(finalFrame is not None and T+seriesFrames>=finalFrame): #If this series has the finalFrame chosen...
+                        finalFrame = finalFrame - T
+                        if(finalFrame >0):
+                            newStack = tffl.series[seriesNr].asarray(key=range(0,finalFrame,step)) #Get next frames
+                            if len(newStack.shape)==2 and len(outputImage.shape)==3: #If the newStack is only one frame, change this into an 3Dstack
+                                outputImage = np.vstack((outputImage,newStack[np.newaxis,:, :]))
+                            else:
+                                outputImage = np.vstack((outputImage,newStack))
+                        break
+                    
+                    else:   #Get all frames from the series
+                        newStack = tffl.series[seriesNr].asarray(key=range(0,seriesFrames,step))
+                        if len(newStack.shape)==2 and len(outputImage.shape)==3:    #If there is only one frame turn it into a 3D array.
+                            outputImage = np.vstack((outputImage,newStack[np.newaxis,:, :]))
+                        else:
+                            outputImage = np.vstack((outputImage,newStack))
+                            
+                #Sum up the frames to which they were iterated
+                T += seriesFrames
+        else:
+            logging.error("The file: " + os.path.basename(file_name) + " is not a TIFF file")
+            return None
+                
+    else:
+        logging.error('Specified file does not exist')
+        return None
+    
+    outputImage = np.array(outputImage).astype(outtype)
+    
+    return outputImage
 
 def load(file_name: Union[str, List[str]],
          fr: float = 30,
@@ -1488,9 +1575,49 @@ def load(file_name: Union[str, List[str]],
             mjv, mnv = scipy.io.matlab.mio.get_matfile_version(byte_stream)
             if mjv == 2:
                 extension = '.h5'
+        
+        if extension == '.nd2':
+            with ND2Reader(file_name) as nd2:
+                
+                if subindices is not None:
+                    if isinstance(subindices,list):
+                        if len(subindices==1):
+                            subindices = slice(0,subindices[0],1)
+                        elif len(subindices)==2:
+                            subindices = slice(subindices[0],subindices[1],1)
+                        else:
+                            subindices = slice(subindices[0],subindices[1],subindices[2])
+                            
+                    input_arr = np.array(nd2)[subindices]
+                else:
+                    input_arr = np.array(nd2)
 
         if extension in ['.tif', '.tiff', '.btf']:  # load tif file
             with tifffile.TiffFile(file_name) as tffl:
+                
+                if len(tffl.series)>1:
+                    logging.warning('Your tif file is multiseries. Performance may be affected.')
+                    
+                    if subindices is not None:
+                        if isinstance(subindices,list):
+                            if len(subindices==1):
+                                subindices = slice(0,subindices[0],1)
+                            elif len(subindices)==2:
+                                subindices = slice(subindices[0],subindices[1],1)
+                            else:
+                                subindices = slice(subindices[0],subindices[1],subindices[2])
+                                
+                        if isinstance(subindices,slice):
+                            if subindices.start==None:
+                                input_arr = load_multiseries_tiff(file_name,initialFrame=0,step=subindices.step,finalFrame=subindices.stop)
+                            else:
+                                input_arr = load_multiseries_tiff(file_name,initialFrame=subindices.start,step=subindices.step,finalFrame=subindices.stop)
+                        else:
+                            #logging.error('Cannot open image indices not in slice or in list type')
+                            raise Exception('Cannot open image indices not in slice or in list type')
+                    else:
+                        input_arr = load_multiseries_tiff(file_name)
+                        
                 multi_page = True if tffl.series[0].shape[0] > 1 else False
                 if len(tffl.pages) == 1:
                     logging.warning('Your tif file is saved a single page' +
@@ -2197,14 +2324,53 @@ def load_iter(file_name, subindices=None, var_name_hdf5: str = 'mov', outtype=np
     """
     if os.path.exists(file_name):
         extension = os.path.splitext(file_name)[1].lower()
-        if extension in ('.tif', '.tiff', '.btf'):
-            Y = tifffile.TiffFile(file_name).pages
-            if subindices is not None:
-                if isinstance(subindices, range):
-                    subindices = slice(subindices.start, subindices.stop, subindices.step)
-                Y = Y[subindices]
-            for y in Y:
-                yield y.asarray().astype(outtype)
+        
+        if extension == '.nd2':
+            nd2 = ND2Reader(file_name)
+            
+            if subindices == None:
+                for y in range(0,nd2.shape[0]):
+                    yield nd2[y].astype(outtype)
+            else:
+                for y in range(subindices.start,nd2.shape[0]):
+                    yield nd2[y].astype(outtype)
+                    
+        elif extension in ('.tif', '.tiff', '.btf'):
+            tffl = tifffile.TiffFile(file_name)
+            
+            ############    MULTISERIES TIFF FILE #############################
+            if len(tffl.series)>1:
+                logging.warning('Your tif file is multiseries. Performance may be affected.')
+                
+                if subindices is not None:
+                    if type(subindices) == slice:
+                        initialFrame = subindices.start
+                        seriesStart=0
+                        
+                        for series in tffl.series[0:len(tffl.series)]:
+                            if len(series)>subindices.start:
+                                initialFrame -=len(series)
+                                seriesStart+=1
+                            else:
+                                break
+                        
+                    for series in tffl.series[seriesStart:len(tffl.series)]: #Get a frame at a time iterativelly
+                            if (series == tffl.series[seriesStart]):
+                                for y in series[initialFrame:]:
+                                    yield y.asarray().astype(outtype)
+                            else:
+                                for y in series:
+                                    yield y.asarray().astype(outtype)
+            
+            else:
+                Y = tifffile.TiffFile(file_name).pages
+                if subindices is not None:
+                    if isinstance(subindices, range):
+                        subindices = slice(subindices.start, subindices.stop, subindices.step)
+                    Y = Y[subindices]
+                for y in Y:
+                    yield y.asarray().astype(outtype)
+        
         elif extension in ('.avi', '.mkv'):
             cap = cv2.VideoCapture(file_name)
             if subindices is None:

--- a/caiman/source_extraction/cnmf/utilities.py
+++ b/caiman/source_extraction/cnmf/utilities.py
@@ -33,6 +33,7 @@ import pylab as pl
 import scipy
 from scipy.sparse import spdiags, issparse, csc_matrix, csr_matrix
 import scipy.ndimage.morphology as morph
+from nd2reader import ND2Reader
 import tifffile
 from typing import List
 # https://github.com/constantinpape/z5/issues/146
@@ -992,13 +993,23 @@ def get_file_size(file_name, var_name_hdf5='mov'):
                     extension = '.h5'
             if extension in ['.tif', '.tiff', '.btf']:
                 tffl = tifffile.TiffFile(file_name)
-                siz = tffl.series[0].shape
-                # tiff files written in append mode
-                if len(siz) < 3:
-                    dims = siz
-                    T = len(tffl.pages)
+                if len(tffl.series)>1:
+                    T = 0
+                    for series in tffl.series:
+                        T +=len(series.pages)
+                    dims = tffl.series[0].pages[0].shape
                 else:
-                    T, dims = siz[0], siz[1:]
+                    siz = tffl.series[0].shape
+                    # tiff files written in append mode
+                    if len(siz) < 3:
+                        dims = siz
+                        T = len(tffl.pages)
+                    else:
+                        T, dims = siz[0], siz[1:]
+            elif extension == '.nd2':
+                nd2 = ND2Reader(file_name)
+                dims=[0,0]
+                T,dims[0],dims[1] = nd2.shape
             elif extension in ('.avi', '.mkv'):
                 cap = cv2.VideoCapture(file_name)
                 dims = [0, 0]


### PR DESCRIPTION
# Description

Add functionality to work with multiseries tif files and nd2 (from Nikon softwares) files. 
These changes can allow people that record in Nikon microscopes to quickly use Caiman functions without data conversion. Also, it can allow to open big tiff files that come in multiseries, or to save big files iterativelly for later use using the append variable of the tifffile.TiffFile.imwrite() function, which stores bigTiff data in various series.

These changes requires nd2reader as a dependency (accessible through conda-forge)

The changes are:
1 - Creation of a load_multiseries_tiff_file function in caiman.base.movies. This function allows opening any sets of frames based on slice() defined frames. 
2 - Change of load and load_iter functions in caiman.base.movie() to allow opening these two file types 
3 - Change of get _file_size function in caiman.source_extraction.cnmf.utilities to also account for these two new file types.

